### PR TITLE
Command line and encoding workaround

### DIFF
--- a/codetree.py
+++ b/codetree.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import re
 
@@ -285,4 +286,17 @@ def test():
         return
 
     find_strays(d)
-    
+
+if __name__ == '__main__':
+    import sys
+
+    if len(sys.argv) == 2:
+        root = sys.argv[1]
+    else:
+        root = '.'
+
+    d = create_source_dictionary(root, ["stdafx.h", "stdafx.cpp"])
+    if d is None:
+        exit()
+
+    find_strays(d)

--- a/codetree.py
+++ b/codetree.py
@@ -125,21 +125,27 @@ def process_file(file_path):
     # have to wrap this in a try-catch block to catch
     # unicode issues
     count = 0
+    success = False
 
-    try: 
-        with open(file_path, 'r') as f:
-            for s in f:
-                # count the lines
-                count = count + s.count(';')
-                
-                # find the includes
-                s = s.strip()
-                if s.startswith("#include"):
-                    headerName = get_filename_from_string(s)
-                    if headerName is not None:
-                        file_info.included_files.append(headerName)
+    for encoding in ['utf8', 'Cp1252']:
+        try:
+            with open(file_path, 'r', encoding=encoding) as f:
+                for s in f:
+                    # count the lines
+                    count = count + s.count(';')
 
-    except UnicodeDecodeError:
+                    # find the includes
+                    s = s.strip()
+                    if s.startswith("#include"):
+                        headerName = get_filename_from_string(s)
+                        if headerName is not None:
+                            file_info.included_files.append(headerName)
+            success = True
+            break
+        except UnicodeDecodeError:
+            pass
+
+    if not success:
         print("Ignored", file_path, "[unicode error]")
 
     f.closed                        


### PR DESCRIPTION
Quick patch to run from the command line, and a workaround for some encoding exceptions. Though seems like there should be a better way to handle the later...
